### PR TITLE
Bump dependencies to fix vulnerability from `cargo audit`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,8 +122,8 @@ serde = { version = "1.0", optional = true, default-features = false, features =
 sha3 = { version = "0.10", optional = true, default-features = false }
 tiny-keccak = { version = "2.0", optional = true, default-features = false, features = [ "keccak" ] }
 unicode-normalization = { version = "0.1", optional = true, default-features = false }
-curve25519-dalek = { version = "3.2", optional = true, default-features = false, features = [ "u64_backend" ] }
-x25519-dalek = { version = "1.1", optional = true, default-features = false, features = [ "u64_backend" ] }
+curve25519-dalek = { version = "4.1.3", optional = true, default-features = false }
+x25519-dalek = { version = "2.0.1", optional = true, default-features = false, features = ["static_secrets", "zeroize"] }
 zeroize = { version = "1.5", optional = true, default-features = false, features = [ "zeroize_derive" ] }
 scrypt = { version = "0.11", optional = true, default-features = false }
 hkdf = { version = "0.12", optional = true, default-features = false }
@@ -141,7 +141,7 @@ hex = { version = "0.4", default-features = false, features = [ "alloc", "std" ]
 rand = { version = "0.8", default-features = false, features = [ "std", "std_rng", "min_const_gen" ] }
 serde = { version = "1.0", default-features = false, features = [ "derive" ] }
 serde_json = { version = "1.0", default-features = false, features = [ "alloc", "std" ] }
-age = { version = "0.9", default-features = false }
+age = { version = "0.10", default-features = false }
 
 [profile.dev]
 split-debuginfo = "unpacked"

--- a/src/encoding/ternary/raw.rs
+++ b/src/encoding/ternary/raw.rs
@@ -101,7 +101,7 @@ pub trait RawEncodingBuf {
     /// Convert this encoding into another encoding.
     /// TODO: Rename this `reencode`
     #[allow(clippy::wrong_self_convention)]
-    fn into_encoding<T: RawEncodingBuf>(this: TritBuf<Self>) -> TritBuf<T>
+    fn into_encoding<T>(this: TritBuf<Self>) -> TritBuf<T>
     where
         Self: Sized,
         T: RawEncodingBuf,

--- a/src/encoding/ternary/tryte.rs
+++ b/src/encoding/ternary/tryte.rs
@@ -107,8 +107,8 @@ impl TryFrom<char> for Tryte {
     fn try_from(c: char) -> Result<Self, Self::Error> {
         match c {
             '9' => Ok(Tryte::Nine),
-            'N'..='Z' => Ok(unsafe { core::mem::transmute((c as u8 - b'N') as i8 - 13) }),
-            'A'..='M' => Ok(unsafe { core::mem::transmute((c as u8 - b'A') as i8 + 1) }),
+            'N'..='Z' => Ok(unsafe { core::mem::transmute::<i8, Self>((c as u8 - b'N') as i8 - 13) }),
+            'A'..='M' => Ok(unsafe { core::mem::transmute::<i8, Self>((c as u8 - b'A') as i8 + 1) }),
             _ => Err(Error::InvalidRepr),
         }
     }
@@ -119,7 +119,7 @@ impl TryFrom<i8> for Tryte {
 
     fn try_from(x: i8) -> Result<Self, Self::Error> {
         match x {
-            -13..=13 => Ok(unsafe { core::mem::transmute(x) }),
+            -13..=13 => Ok(unsafe { core::mem::transmute::<i8, Self>(x) }),
             _ => Err(Error::InvalidRepr),
         }
     }

--- a/src/hashes/ternary/curl_p/batched/mod.rs
+++ b/src/hashes/ternary/curl_p/batched/mod.rs
@@ -21,7 +21,7 @@ use crate::{
 
 /// The number of inputs that can be processed in a single batch.
 pub const BATCH_SIZE: usize = 8 * core::mem::size_of::<usize>();
-const HIGH_BITS: usize = usize::max_value();
+const HIGH_BITS: usize = usize::MAX;
 const NUM_ROUNDS: usize = 81;
 
 /// A hasher that can process several inputs at the same time in batches.

--- a/src/hashes/ternary/kerl/bigint/i384/mod.rs
+++ b/src/hashes/ternary/kerl/bigint/i384/mod.rs
@@ -186,7 +186,7 @@ impl Ord for I384<BigEndian, U8Repr> {
         // MSU8s are equal. If they are not equal, then an early return will be triggered.
 
         const NEGBIT: u8 = 0x80;
-        const UMAX: u8 = core::u8::MAX;
+        const UMAX: u8 = u8::MAX;
         let numbers_negative = match zipped_iter.next() {
             // Case 1: both numbers are negative, s is less.
             Some((s @ NEGBIT..=UMAX, o @ NEGBIT..=UMAX)) if s > o => return Greater,
@@ -408,7 +408,7 @@ impl Ord for I384<BigEndian, U32Repr> {
         // MSU32s are equal. If they are not equal, then an early return will be triggered.
 
         const NEGBIT: u32 = 0x8000_0000;
-        const UMAX: u32 = core::u32::MAX;
+        const UMAX: u32 = u32::MAX;
         let numbers_negative = match zipped_iter.next() {
             // Case 1: both numbers are negative, s is less.
             Some((s @ NEGBIT..=UMAX, o @ NEGBIT..=UMAX)) if s > o => return Greater,
@@ -504,7 +504,7 @@ impl Ord for I384<LittleEndian, U8Repr> {
         // MSU8s are equal. If they are not equal, then an early return will be triggered.
 
         const NEGBIT: u8 = 0x80;
-        const UMAX: u8 = core::u8::MAX;
+        const UMAX: u8 = u8::MAX;
         let numbers_negative = match zipped_iter.next() {
             // Case 1: both numbers are negative, s is less.
             Some((s @ NEGBIT..=UMAX, o @ NEGBIT..=UMAX)) if s > o => return Greater,
@@ -734,7 +734,7 @@ impl Ord for I384<LittleEndian, U32Repr> {
         // MSU32s are equal. If they are not equal, then an early return will be triggered.
 
         const NEGBIT: u32 = 0x8000_0000;
-        const UMAX: u32 = core::u32::MAX;
+        const UMAX: u32 = u32::MAX;
 
         let numbers_negative = match zipped_iter.next() {
             // Case 1: both numbers are negative, s is less.

--- a/src/hashes/ternary/kerl/bigint/split_integer.rs
+++ b/src/hashes/ternary/kerl/bigint/split_integer.rs
@@ -66,18 +66,18 @@ mod tests {
         // i64
         [split_i64_hi_one_is_zero, 1i64.hi(), 0i32],
         [split_i64_lo_one_is_one, 1i64.lo(), 1u32],
-        [split_i64_hi_max_is_max, i64::max_value().hi(), i32::max_value()],
-        [split_i64_lo_max_is_max, i64::max_value().lo(), u32::max_value()],
-        [split_i64_hi_min_is_min, i64::min_value().hi(), i32::min_value()],
-        [split_i64_lo_min_is_zero, i64::min_value().lo(), 0u32],
+        [split_i64_hi_max_is_max, i64::MAX.hi(), i32::MAX],
+        [split_i64_lo_max_is_max, i64::MAX.lo(), u32::MAX],
+        [split_i64_hi_min_is_min, i64::MIN.hi(), i32::MIN],
+        [split_i64_lo_min_is_zero, i64::MIN.lo(), 0u32],
         [split_i64_hi_neg_one_is_neg_one, (-1i64).hi(), -1i32],
-        [split_i64_lo_neg_one_is_max, (-1i64).lo(), u32::max_value()],
+        [split_i64_lo_neg_one_is_max, (-1i64).lo(), u32::MAX],
         // u64
         [split_u64_hi_one_is_zero, 1u64.hi(), 0u32],
         [split_u64_lo_one_is_one, 1u64.lo(), 1u32],
-        [split_u64_hi_max_is_max, u64::max_value().hi(), u32::max_value()],
-        [split_u64_lo_max_is_max, u64::max_value().lo(), u32::max_value()],
-        [split_u64_hi_min_is_min, u64::min_value().hi(), 0u32],
-        [split_u64_lo_min_is_zero, u64::min_value().lo(), 0u32],
+        [split_u64_hi_max_is_max, u64::MAX.hi(), u32::MAX],
+        [split_u64_lo_max_is_max, u64::MAX.lo(), u32::MAX],
+        [split_u64_hi_min_is_min, u64::MIN.hi(), 0u32],
+        [split_u64_lo_min_is_zero, u64::MIN.lo(), 0u32],
     );
 }

--- a/src/keys/bip39.rs
+++ b/src/keys/bip39.rs
@@ -60,7 +60,7 @@ impl<'a> TryFrom<&'a str> for &'a MnemonicRef {
     fn try_from(mnemonic_str: &'a str) -> Result<Self, Error> {
         if is_nfkd(mnemonic_str) {
             // SAFETY: MnemonicRef is represented exactly as str due to repr(transparent)
-            Ok(unsafe { core::mem::transmute(mnemonic_str) })
+            Ok(unsafe { core::mem::transmute::<&str, Self>(mnemonic_str) })
         } else {
             Err(Error::UnnormalizedMnemonic)
         }
@@ -196,7 +196,7 @@ impl<'a> TryFrom<&'a str> for &'a PassphraseRef {
     fn try_from(passphrase_str: &'a str) -> Result<Self, Error> {
         if is_nfkd(passphrase_str) {
             // SAFETY: PassphraseRef is represented exactly as str due to repr(transparent)
-            Ok(unsafe { core::mem::transmute(passphrase_str) })
+            Ok(unsafe { core::mem::transmute::<&str, Self>(passphrase_str) })
         } else {
             Err(Error::UnnormalizedPassphrase)
         }


### PR DESCRIPTION
# Description of change

Running `cargo audit` in [identity.rs](https://github.com/iotaledger/identity.rs) currently producing errors due to vulnerabilities in the current `curve25519-dalek` version:

```raw
Crate:     curve25519-dalek
Version:   3.2.0
Title:     Timing variability in `curve25519-dalek`'s `Scalar29::sub`/`Scalar52::sub`
Date:      2024-06-18
ID:        RUSTSEC-2024-0344
URL:       https://rustsec.org/advisories/RUSTSEC-2024-0344
Solution:  Upgrade to >=4.1.3
Dependency tree:
curve25519-dalek 3.2.0
├── x25519-dalek 1.1.1
│   ├── iota-crypto 0.23.1
│   └── age 0.9.2
│       └── iota-crypto 0.23.1
└── iota-crypto 0.23.1

error: 1 vulnerability found!
```

Same audit message could be produces when running `cargo audit` in [crypto.rs](https://github.com/iotaledger/crypto.rs). This PR bumps the dependencies to fix the vulnerability.

Changes:

- bump dependencies to latest versions:
  - `curve25519-dalek`
  - `x25519-dalek`
  - `age`
- remove by now outdated feature `u64_backend` for 
  - `curve25519-dalek`
  - `x25519-dalek`
- enable features for `x25519-dalek`:
  - `static_secrets`
  - `zeroize`
- fix `cargo clippy` messages from CI 

The features `static_secrets` and `zeroize` had to be enabled for `x25519-dalek` so that [identity.rs](https://github.com/iotaledger/identity.rs) to be able to use [crypto.rs](https://github.com/iotaledger/crypto.rs) with the updated dependencies.

## ⚠️ There may be dragons (or not)

Interestingly, all tests run with `cargo test --lib --all --all-features --tests` completed successfully without the features `static_secrets` and `zeroize`, but building [identity.rs](https://github.com/iotaledger/identity.rs) against a version without those features enabled fails due to:

- `x25519_dalek::StaticSecret` not being found in `crypto.rs/src/keys/x25519.rs:105`
- not being able to derive `Zeroize` and `ZeroizeOnDrop` in `crypto.rs/src/keys/x25519.rs:105`

So the outward behavior changes without those features.

I'm not entirely sure, if similar behavior changes may affect other dependents similarly for other features.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Enhancement (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix
- [x] Chore?

## How the change has been tested

`cargo audit` on current `dev` should produce the message from above, doing the same on this branch should not.

Tested locally and verified with CI.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
